### PR TITLE
Fix SwapChainPanel resize crash

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainPanelNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainPanelNativeWindow.cpp
@@ -325,6 +325,11 @@ HRESULT SwapChainPanelNativeWindow::createSwapChain(ID3D11Device *device,
 
 HRESULT SwapChainPanelNativeWindow::scaleSwapChain(const Size &windowSize, const RECT &clientRect)
 {
+    if (!mSwapChain) 
+    {
+        return E_FAIL;
+    }
+
     Size renderScale = {windowSize.Width / (float)clientRect.right,
                         windowSize.Height / (float)clientRect.bottom};
     // Setup a scale matrix for the swap chain


### PR DESCRIPTION
A `SizeChanged` event from a `SwapChainPanel` might be fired on the UI-thread before the underlying SwapChain creation has finished inside the `eglCreateWindowSurface()` call on the render thread.

This adds the missing null check.