### PR TITLE
[GFX-591] EXT_external_buffer support for D3D11 (VB and IB only)

### DIFF
--- a/src/libANGLE/ErrorStrings.h
+++ b/src/libANGLE/ErrorStrings.h
@@ -65,6 +65,7 @@ MSG kBufferOffsetOverflow = "Buffer offset overflow.";
 MSG kBufferPointerNotAvailable = "Can not get pointer for reserved buffer name zero.";
 MSG kCannotPopDefaultDebugGroup = "Cannot pop the default debug group.";
 MSG kClientBufferInvalid = "Size must not exceed the size of clientbuffer";
+MSG kClientBufferNoSharedAccess = "Clientbuffer must be allocated in a way which permits shared access by the GPU";
 MSG kClientDataInVertexArray = "Client data cannot be used with a non-default vertex array object.";
 MSG kColorNumberGreaterThanMaxDrawBuffers = "Color number for primary color greater than or equal to MAX_DRAW_BUFFERS";
 MSG kColorNumberGreaterThanMaxDualSourceDrawBuffers = "Color number for secondary color greater than or equal to MAX_DUAL_SOURCE_DRAW_BUFFERS";

--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -424,13 +424,7 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
         }
         SafeRelease(device);
 
-        if (flags & GL_MAP_PERSISTENT_BIT_EXT)
-        {
-            clientBufferPermitsSharedAccess = false;
-        }
-        if ((flags & GL_MAP_READ_BIT) &&
-            !(clientBufferDesc11.Usage == D3D11_USAGE_DYNAMIC &&
-              clientBufferDesc11.CPUAccessFlags & D3D11_CPU_ACCESS_READ))
+        if (flags & (GL_MAP_PERSISTENT_BIT_EXT | GL_MAP_READ_BIT))
         {
             clientBufferPermitsSharedAccess = false;
         }

--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -398,6 +398,10 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
 {
     if (clientBuffer)
     {
+        // Table 6.3 in specification of EXT_buffer_storage states that
+        // calling BufferStorage() (and as consequence BufferStorageExternal())
+        // modifies the buffer object state such that BUFFER_USAGE is set to
+        // DYNAMIC_DRAW.
         updateD3DBufferUsage(context, gl::BufferUsage::DynamicDraw);
 
         auto *contextD3D     = GetImplAs<ContextD3D>(context);

--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -12,6 +12,7 @@
 
 #include "common/MemoryBuffer.h"
 #include "libANGLE/Context.h"
+#include "libANGLE/ErrorStrings.h"
 #include "libANGLE/renderer/d3d/IndexDataManager.h"
 #include "libANGLE/renderer/d3d/VertexDataManager.h"
 #include "libANGLE/renderer/d3d/d3d11/Context11.h"
@@ -158,7 +159,8 @@ class Buffer11::NativeStorage : public Buffer11::BufferStorage
     NativeStorage(Renderer11 *renderer,
                   BufferUsage usage,
                   const angle::Subject *onStorageChanged,
-                  d3d11::Buffer* buffer = nullptr, size_t bufferSize = 0);
+                  d3d11::Buffer *buffer = nullptr,
+                  size_t bufferSize     = 0);
     ~NativeStorage() override;
 
     bool isCPUAccessible(GLbitfield access) const override;
@@ -396,7 +398,57 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
 {
     if (clientBuffer)
     {
-        updateD3DBufferUsage(context, gl::BufferUsage::StaticDraw);
+        updateD3DBufferUsage(context, gl::BufferUsage::DynamicDraw);
+
+        auto *contextD3D     = GetImplAs<ContextD3D>(context);
+        auto *clientBuffer11 = static_cast<ID3D11Buffer *>(clientBuffer);
+
+        D3D11_BUFFER_DESC clientBufferDesc11;
+        clientBuffer11->GetDesc(&clientBufferDesc11);
+
+        bool clientBufferSizeValid = clientBufferDesc11.ByteWidth >= size;
+        ANGLE_CHECK(contextD3D, clientBufferSizeValid, gl::err::kClientBufferInvalid,
+                    GL_INVALID_VALUE);
+
+        bool clientBufferPermitsSharedAccess = true;
+
+        ID3D11Device *device;
+        clientBuffer11->GetDevice(&device);
+        if (mRenderer->getDevice() != device)
+        {
+            clientBufferPermitsSharedAccess = false;
+        }
+        SafeRelease(device);
+
+        if (flags & GL_MAP_PERSISTENT_BIT_EXT)
+        {
+            clientBufferPermitsSharedAccess = false;
+        }
+        if ((flags & GL_MAP_READ_BIT) &&
+            !(clientBufferDesc11.Usage == D3D11_USAGE_DYNAMIC &&
+              clientBufferDesc11.CPUAccessFlags & D3D11_CPU_ACCESS_READ))
+        {
+            clientBufferPermitsSharedAccess = false;
+        }
+        if ((flags & GL_MAP_WRITE_BIT) &&
+            !(clientBufferDesc11.Usage == D3D11_USAGE_DYNAMIC &&
+              clientBufferDesc11.CPUAccessFlags & D3D11_CPU_ACCESS_WRITE))
+        {
+            clientBufferPermitsSharedAccess = false;
+        }
+        if (target == gl::BufferBinding::Array &&
+            !(clientBufferDesc11.BindFlags & D3D11_BIND_VERTEX_BUFFER))
+        {
+            clientBufferPermitsSharedAccess = false;
+        }
+        if (target == gl::BufferBinding::ElementArray &&
+            !(clientBufferDesc11.BindFlags & D3D11_BIND_INDEX_BUFFER))
+        {
+            clientBufferPermitsSharedAccess = false;
+        }
+
+        ANGLE_CHECK(contextD3D, clientBufferPermitsSharedAccess,
+                    gl::err::kClientBufferNoSharedAccess, GL_INVALID_OPERATION);
 
         rx::BufferUsage bufferUsage;
         switch (target)
@@ -408,10 +460,10 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
                 bufferUsage = BUFFER_USAGE_INDEX;
                 break;
             default:
-                return angle::Result::Stop;
+                ANGLE_CHECK(contextD3D, false, "Unsupported target", GL_INVALID_OPERATION);
         }
 
-        d3d11::Buffer buffer(reinterpret_cast<ID3D11Buffer*>(clientBuffer), nullptr);
+        d3d11::Buffer buffer(clientBuffer11, nullptr);
         BufferStorage *storage = new NativeStorage(mRenderer, bufferUsage, nullptr, &buffer, size);
         onStorageUpdate(storage);
         mBufferStorages[bufferUsage] = storage;
@@ -1171,13 +1223,13 @@ angle::Result Buffer11::BufferStorage::setData(const gl::Context *context,
 Buffer11::NativeStorage::NativeStorage(Renderer11 *renderer,
                                        BufferUsage usage,
                                        const angle::Subject *onStorageChanged,
-                                       d3d11::Buffer *buffer, 
+                                       d3d11::Buffer *buffer,
                                        size_t bufferSize)
     : BufferStorage(renderer, usage), mBuffer(), mOnStorageChanged(onStorageChanged)
 {
     if (buffer)
     {
-        mBuffer = std::move(*buffer);
+        mBuffer     = std::move(*buffer);
         mBufferSize = bufferSize;
     }
 }

--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -155,7 +155,10 @@ class Buffer11::BufferStorage : angle::NonCopyable
 class Buffer11::NativeStorage : public Buffer11::BufferStorage
 {
   public:
-    NativeStorage(Renderer11 *renderer, BufferUsage usage, const angle::Subject *onStorageChanged);
+    NativeStorage(Renderer11 *renderer,
+                  BufferUsage usage,
+                  const angle::Subject *onStorageChanged,
+                  d3d11::Buffer* buffer = nullptr, size_t bufferSize = 0);
     ~NativeStorage() override;
 
     bool isCPUAccessible(GLbitfield access) const override;
@@ -381,6 +384,46 @@ angle::Result Buffer11::setData(const gl::Context *context,
 {
     updateD3DBufferUsage(context, usage);
     return setSubData(context, target, data, size, 0);
+}
+
+angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
+                                              gl::BufferBinding target,
+                                              GLeglClientBufferEXT clientBuffer,
+                                              const void *data,
+                                              size_t size,
+                                              gl::BufferUsage usage,
+                                              GLbitfield flags)
+{
+    if (clientBuffer)
+    {
+        updateD3DBufferUsage(context, gl::BufferUsage::StaticDraw);
+
+        rx::BufferUsage bufferUsage;
+        switch (target)
+        {
+            case gl::BufferBinding::Array:
+                bufferUsage = BUFFER_USAGE_VERTEX_OR_TRANSFORM_FEEDBACK;
+                break;
+            case gl::BufferBinding::ElementArray:
+                bufferUsage = BUFFER_USAGE_INDEX;
+                break;
+            default:
+                return angle::Result::Stop;
+        }
+
+        d3d11::Buffer buffer(reinterpret_cast<ID3D11Buffer*>(clientBuffer), nullptr);
+        BufferStorage *storage = new NativeStorage(mRenderer, bufferUsage, nullptr, &buffer, size);
+        onStorageUpdate(storage);
+        mBufferStorages[bufferUsage] = storage;
+
+        mSize = size;
+
+        return angle::Result::Continue;
+    }
+    else
+    {
+        return setData(context, target, data, size, usage);
+    }
 }
 
 angle::Result Buffer11::getData(const gl::Context *context, const uint8_t **outData)
@@ -1127,9 +1170,17 @@ angle::Result Buffer11::BufferStorage::setData(const gl::Context *context,
 
 Buffer11::NativeStorage::NativeStorage(Renderer11 *renderer,
                                        BufferUsage usage,
-                                       const angle::Subject *onStorageChanged)
+                                       const angle::Subject *onStorageChanged,
+                                       d3d11::Buffer *buffer, 
+                                       size_t bufferSize)
     : BufferStorage(renderer, usage), mBuffer(), mOnStorageChanged(onStorageChanged)
-{}
+{
+    if (buffer)
+    {
+        mBuffer = std::move(*buffer);
+        mBufferSize = bufferSize;
+    }
+}
 
 Buffer11::NativeStorage::~NativeStorage()
 {

--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.h
@@ -96,6 +96,13 @@ class Buffer11 : public BufferD3D
     void invalidateStaticData(const gl::Context *context) override;
 
     // BufferImpl implementation
+    angle::Result setDataWithUsageFlags(const gl::Context *context,
+                                        gl::BufferBinding target,
+                                        GLeglClientBufferEXT clientBuffer,
+                                        const void *data,
+                                        size_t size,
+                                        gl::BufferUsage usage,
+                                        GLbitfield flags) override;
     angle::Result setData(const gl::Context *context,
                           gl::BufferBinding target,
                           const void *data,

--- a/src/libANGLE/renderer/d3d/d3d11/ResourceManager11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/ResourceManager11.h
@@ -254,6 +254,7 @@ class Resource11 : public Resource11Base<ResourceT, UniquePtr, TypedData<Resourc
     template <typename T>
     friend class SharedResource11;
     friend class ResourceManager11;
+    friend class Buffer11;
 
     Resource11(ResourceT *object, ResourceManager11 *manager)
     {

--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -1634,6 +1634,7 @@ void GenerateCaps(ID3D11Device *device,
     extensions->unpackSubimage                      = true;
     extensions->packSubimage                        = true;
     extensions->lossyETCDecode                      = true;
+    extensions->externalBufferEXT                   = true;
     extensions->syncQuery                           = GetEventQuerySupport(featureLevel);
     extensions->copyTexture                         = true;
     extensions->copyCompressedTexture               = true;


### PR DESCRIPTION
Add support for passing external (D3D11) buffers to vertex and index buffers.

For testing purposes, I recommend using the branch `GFX-591_ALL`.