### PR TITLE
[GFX-591] Add support for filtering BGRA EGLConfigs

### DIFF
--- a/include/EGL/eglext_angle.h
+++ b/include/EGL/eglext_angle.h
@@ -355,6 +355,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglSwapBuffersWithFrameTokenANGLE(EGLDisplay dpy, 
 #define EGL_EXTERNAL_CONTEXT_SAVE_STATE_ANGLE 0x3490
 #endif /* EGL_ANGLE_external_context_and_surface */
 
+// Shapr3D uses it!
+#define EGL_TEXTURE_SWIZZLING_TYPE 0x35FF
+#define EGL_TEXTURE_SWIZZLING_BGRA 0x35FE
+#define EGL_TEXTURE_SWIZZLING_RGBA 0x35FD
+
 // clang-format on
 
 #endif  // INCLUDE_EGL_EGLEXT_ANGLE_

--- a/include/EGL/eglext_angle.h
+++ b/include/EGL/eglext_angle.h
@@ -355,7 +355,6 @@ EGLAPI EGLBoolean EGLAPIENTRY eglSwapBuffersWithFrameTokenANGLE(EGLDisplay dpy, 
 #define EGL_EXTERNAL_CONTEXT_SAVE_STATE_ANGLE 0x3490
 #endif /* EGL_ANGLE_external_context_and_surface */
 
-// Shapr3D uses it!
 #define EGL_TEXTURE_SWIZZLING_TYPE 0x35FF
 #define EGL_TEXTURE_SWIZZLING_BGRA 0x35FE
 #define EGL_TEXTURE_SWIZZLING_RGBA 0x35FD

--- a/src/libANGLE/Config.cpp
+++ b/src/libANGLE/Config.cpp
@@ -372,6 +372,17 @@ std::vector<const Config *> ConfigSet::filter(const AttributeMap &attributeMap) 
                 case EGL_Y_INVERTED_NOK:
                     match = config.yInverted == static_cast<EGLBoolean>(attributeValue);
                     break;
+                case EGL_TEXTURE_SWIZZLING_TYPE:
+                    switch (attributeValue)
+                    {
+                        case EGL_TEXTURE_SWIZZLING_BGRA:
+                            match = config.renderTargetFormat == GL_BGRA8_EXT;
+                            break;
+                        case EGL_TEXTURE_SWIZZLING_RGBA:
+                            match = config.renderTargetFormat != GL_BGRA8_EXT;
+                            break;
+                    }
+                    break;
                 default:
                     UNREACHABLE();
             }

--- a/src/libANGLE/queryutils.cpp
+++ b/src/libANGLE/queryutils.cpp
@@ -4140,6 +4140,10 @@ void QueryConfigAttrib(const Config *config, EGLint attribute, EGLint *value)
         case EGL_FRAMEBUFFER_TARGET_ANDROID:
             *value = config->framebufferTarget;
             break;
+        case EGL_TEXTURE_SWIZZLING_TYPE:
+            *value = config->renderTargetFormat == GL_BGRA8_EXT ? EGL_TEXTURE_SWIZZLING_BGRA
+                                                                : EGL_TEXTURE_SWIZZLING_RGBA;
+            break;
         default:
             UNREACHABLE();
             break;

--- a/src/libANGLE/validationEGL.cpp
+++ b/src/libANGLE/validationEGL.cpp
@@ -207,6 +207,7 @@ bool ValidateConfigAttribute(const ValidationContext *val,
         case EGL_MAX_PBUFFER_WIDTH:
         case EGL_MAX_PBUFFER_HEIGHT:
         case EGL_MAX_PBUFFER_PIXELS:
+        case EGL_TEXTURE_SWIZZLING_TYPE:
             break;
 
         case EGL_OPTIMAL_SURFACE_ORIENTATION_ANGLE:
@@ -360,6 +361,20 @@ bool ValidateConfigAttributeValue(const ValidationContext *val,
                 default:
                     val->setError(EGL_BAD_ATTRIBUTE,
                                   "EGL_COLOR_COMPONENT_TYPE_EXT invalid attribute: 0x%X",
+                                  static_cast<uint32_t>(value));
+                    return false;
+            }
+            break;
+        case EGL_TEXTURE_SWIZZLING_TYPE:
+            switch (value)
+            {
+                case EGL_TEXTURE_SWIZZLING_BGRA:
+                case EGL_TEXTURE_SWIZZLING_RGBA:
+                case EGL_DONT_CARE:
+                    break;
+                default:
+                    val->setError(EGL_BAD_ATTRIBUTE,
+                                  "EGL_TEXTURE_SWIZZLING_TYPE invalid attribute: 0x%X",
                                   static_cast<uint32_t>(value));
                     return false;
             }


### PR DESCRIPTION
Add a flag for filtering EGLConfigs before choosing one. We use BGRA format swapchain in Shapr3D and there was no way to make the EGL context use BGRA without this flag.

For testing purposes, I recommend using the branch `GFX-591_ALL`.