### PR TITLE
[GFX-591] Can pass external swapchain to D3D11 as EGL native window

### DIFF
--- a/src/libANGLE/renderer/d3d/BUILD.gn
+++ b/src/libANGLE/renderer/d3d/BUILD.gn
@@ -264,6 +264,8 @@ if (angle_enable_d3d11) {
       "d3d11/winrt/NativeWindow11WinRT.h",
       "d3d11/winrt/SwapChainPanelNativeWindow.cpp",
       "d3d11/winrt/SwapChainPanelNativeWindow.h",
+      "d3d11/winrt/SwapChainNativeWindow.cpp",
+      "d3d11/winrt/SwapChainNativeWindow.h",
     ]
   } else {
     _d3d11_backend_sources += [

--- a/src/libANGLE/renderer/d3d/d3d11/SwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/SwapChain11.cpp
@@ -503,7 +503,7 @@ EGLint SwapChain11::resize(DisplayD3D *displayD3D, EGLint backbufferWidth, EGLin
     }
 
     hr = mSwapChain->ResizeBuffers(desc.BufferCount, backbufferWidth, backbufferHeight,
-                                   getSwapChainNativeFormat(), 0);
+                                   getSwapChainNativeFormat(), desc.Flags);
 
     if (FAILED(hr))
     {

--- a/src/libANGLE/renderer/d3d/d3d11/SwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/SwapChain11.cpp
@@ -69,7 +69,7 @@ SwapChain11::SwapChain11(Renderer11 *renderer,
       mPassThroughResourcesInit(false),
       mNativeWindow(nativeWindow),
       mFirstSwap(true),
-      mSwapEffectDiscards(false),
+      mIsSwapEffectDiscarding(false),
       mSwapChain(nullptr),
       mSwapChain1(nullptr),
       mKeyedMutex(nullptr),
@@ -669,11 +669,11 @@ EGLint SwapChain11::reset(DisplayD3D *displayD3D,
         {
             case DXGI_SWAP_EFFECT_DISCARD:
             case DXGI_SWAP_EFFECT_FLIP_DISCARD:
-                mSwapEffectDiscards = true;
+                mIsSwapEffectDiscarding = true;
                 break;
             case DXGI_SWAP_EFFECT_SEQUENTIAL:
             case DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL:
-                mSwapEffectDiscards = false;
+                mIsSwapEffectDiscarding = false;
                 break;
         }
 
@@ -945,7 +945,7 @@ EGLint SwapChain11::present(DisplayD3D *displayD3D, EGLint x, EGLint y, EGLint w
     // Dirty rect present is not supported with a multisampled swapchain.
     // Partial Presentation (using a dirty rects or scroll) is not supported for SwapChains created
     // with DXGI_SWAP_EFFECT_DISCARD or DXGI_SWAP_EFFECT_FLIP_DISCARD
-    if (mSwapChain1 != nullptr && mEGLSamples <= 1 && !mSwapEffectDiscards)
+    if (mSwapChain1 != nullptr && mEGLSamples <= 1 && !mIsSwapEffectDiscarding)
     {
         if (mFirstSwap)
         {

--- a/src/libANGLE/renderer/d3d/d3d11/SwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/SwapChain11.cpp
@@ -534,15 +534,21 @@ EGLint SwapChain11::resize(DisplayD3D *displayD3D, EGLint backbufferWidth, EGLin
         mBackBufferTexture.set(backbufferTexture, format);
         mBackBufferTexture.setDebugName("BackBufferTexture");
 
-        angle::Result result = mRenderer->allocateResourceNoDesc(
-            displayD3D, mBackBufferTexture.get(), &mBackBufferRTView);
-        ASSERT(result != angle::Result::Stop);
-        mBackBufferRTView.setDebugName("BackBufferRTV");
+        if (desc.BufferUsage & DXGI_USAGE_RENDER_TARGET_OUTPUT)
+        {
+            angle::Result result = mRenderer->allocateResourceNoDesc(
+                displayD3D, mBackBufferTexture.get(), &mBackBufferRTView);
+            ASSERT(result != angle::Result::Stop);
+            mBackBufferRTView.setDebugName("BackBufferRTV");
+        }
 
-        result = mRenderer->allocateResourceNoDesc(displayD3D, mBackBufferTexture.get(),
-                                                   &mBackBufferSRView);
-        ASSERT(result != angle::Result::Stop);
-        mBackBufferSRView.setDebugName("BackBufferSRV");
+        if (desc.BufferUsage & DXGI_USAGE_SHADER_INPUT)
+        {
+            angle::Result result = mRenderer->allocateResourceNoDesc(
+                displayD3D, mBackBufferTexture.get(), &mBackBufferSRView);
+            ASSERT(result != angle::Result::Stop);
+            mBackBufferSRView.setDebugName("BackBufferSRV");
+        }
     }
 
     mFirstSwap = true;
@@ -649,6 +655,15 @@ EGLint SwapChain11::reset(DisplayD3D *displayD3D,
             mSwapChain1 = d3d11::DynamicCastComObject<IDXGISwapChain1>(mSwapChain);
         }
 
+        DXGI_SWAP_CHAIN_DESC swapChainDesc;
+        hr = mSwapChain->GetDesc(&swapChainDesc);
+        if (FAILED(hr))
+        {
+            ERR() << "Error reading swap chain description, " << gl::FmtHR(hr);
+            release();
+            return EGL_BAD_ALLOC;
+        }
+
         ID3D11Texture2D *backbufferTex = nullptr;
         hr                             = mSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D),
                                    reinterpret_cast<LPVOID *>(&backbufferTex));
@@ -658,15 +673,21 @@ EGLint SwapChain11::reset(DisplayD3D *displayD3D,
         mBackBufferTexture.set(backbufferTex, format);
         mBackBufferTexture.setDebugName("BackBufferTexture");
 
-        angle::Result result = mRenderer->allocateResourceNoDesc(
-            displayD3D, mBackBufferTexture.get(), &mBackBufferRTView);
-        ASSERT(result != angle::Result::Stop);
-        mBackBufferRTView.setDebugName("BackBufferRTV");
+        if (swapChainDesc.BufferUsage & DXGI_USAGE_RENDER_TARGET_OUTPUT)
+        {
+            angle::Result result = mRenderer->allocateResourceNoDesc(
+                displayD3D, mBackBufferTexture.get(), &mBackBufferRTView);
+            ASSERT(result != angle::Result::Stop);
+            mBackBufferRTView.setDebugName("BackBufferRTV");
+        }
 
-        result = mRenderer->allocateResourceNoDesc(displayD3D, mBackBufferTexture.get(),
-                                                   &mBackBufferSRView);
-        ASSERT(result != angle::Result::Stop);
-        mBackBufferSRView.setDebugName("BackBufferSRV");
+        if (swapChainDesc.BufferUsage & DXGI_USAGE_SHADER_INPUT)
+        {
+            angle::Result result = mRenderer->allocateResourceNoDesc(
+                displayD3D, mBackBufferTexture.get(), &mBackBufferSRView);
+            ASSERT(result != angle::Result::Stop);
+            mBackBufferSRView.setDebugName("BackBufferSRV");
+        }
     }
 
     mFirstSwap = true;

--- a/src/libANGLE/renderer/d3d/d3d11/SwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/SwapChain11.cpp
@@ -69,6 +69,7 @@ SwapChain11::SwapChain11(Renderer11 *renderer,
       mPassThroughResourcesInit(false),
       mNativeWindow(nativeWindow),
       mFirstSwap(true),
+      mSwapEffectDiscards(false),
       mSwapChain(nullptr),
       mSwapChain1(nullptr),
       mKeyedMutex(nullptr),
@@ -664,6 +665,18 @@ EGLint SwapChain11::reset(DisplayD3D *displayD3D,
             return EGL_BAD_ALLOC;
         }
 
+        switch (swapChainDesc.SwapEffect)
+        {
+            case DXGI_SWAP_EFFECT_DISCARD:
+            case DXGI_SWAP_EFFECT_FLIP_DISCARD:
+                mSwapEffectDiscards = true;
+                break;
+            case DXGI_SWAP_EFFECT_SEQUENTIAL:
+            case DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL:
+                mSwapEffectDiscards = false;
+                break;
+        }
+
         ID3D11Texture2D *backbufferTex = nullptr;
         hr                             = mSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D),
                                    reinterpret_cast<LPVOID *>(&backbufferTex));
@@ -930,7 +943,9 @@ EGLint SwapChain11::present(DisplayD3D *displayD3D, EGLint x, EGLint y, EGLint w
 
     // Use IDXGISwapChain1::Present1 with a dirty rect if DXGI 1.2 is available.
     // Dirty rect present is not supported with a multisampled swapchain.
-    if (mSwapChain1 != nullptr && mEGLSamples <= 1)
+    // Partial Presentation (using a dirty rects or scroll) is not supported for SwapChains created
+    // with DXGI_SWAP_EFFECT_DISCARD or DXGI_SWAP_EFFECT_FLIP_DISCARD
+    if (mSwapChain1 != nullptr && mEGLSamples <= 1 && !mSwapEffectDiscards)
     {
         if (mFirstSwap)
         {

--- a/src/libANGLE/renderer/d3d/d3d11/SwapChain11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/SwapChain11.h
@@ -96,6 +96,7 @@ class SwapChain11 final : public SwapChainD3D
     NativeWindow11 *mNativeWindow;  // Handler for the Window that the surface is created for.
 
     bool mFirstSwap;
+    bool mSwapEffectDiscards;
     IDXGISwapChain *mSwapChain;
     IDXGISwapChain1 *mSwapChain1;
     IDXGIKeyedMutex *mKeyedMutex;

--- a/src/libANGLE/renderer/d3d/d3d11/SwapChain11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/SwapChain11.h
@@ -96,7 +96,7 @@ class SwapChain11 final : public SwapChainD3D
     NativeWindow11 *mNativeWindow;  // Handler for the Window that the surface is created for.
 
     bool mFirstSwap;
-    bool mSwapEffectDiscards;
+    bool mIsSwapEffectDiscarding;
     IDXGISwapChain *mSwapChain;
     IDXGISwapChain1 *mSwapChain1;
     IDXGIKeyedMutex *mKeyedMutex;

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/InspectableNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/InspectableNativeWindow.cpp
@@ -57,6 +57,26 @@ bool IsSwapChainPanel(EGLNativeWindowType window,
     return false;
 }
 
+bool IsSwapChain(EGLNativeWindowType window, ComPtr<IDXGISwapChain>* swapChain) {
+    if (!window)
+    {
+        return false;
+    }
+
+    ComPtr<IInspectable> win = window;
+    ComPtr<IDXGISwapChain> sc;
+    if (SUCCEEDED(win.As(&sc)))
+    {
+        if (swapChain != nullptr)
+        {
+            *swapChain = std::move(sc);
+        }
+        return true;
+    }
+
+    return false;
+}
+
 bool IsEGLConfiguredPropertySet(EGLNativeWindowType window,
                                 ABI::Windows::Foundation::Collections::IPropertySet **propertySet,
                                 IInspectable **eglNativeWindow)

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/InspectableNativeWindow.h
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/InspectableNativeWindow.h
@@ -123,6 +123,7 @@ bool IsCoreWindow(EGLNativeWindowType window,
 bool IsSwapChainPanel(
     EGLNativeWindowType window,
     ComPtr<ABI::Windows::UI::Xaml::Controls::ISwapChainPanel> *swapChainPanel = nullptr);
+bool IsSwapChain(EGLNativeWindowType window, ComPtr<IDXGISwapChain> *swapChain = nullptr);
 bool IsEGLConfiguredPropertySet(
     EGLNativeWindowType window,
     ABI::Windows::Foundation::Collections::IPropertySet **propertySet = nullptr,

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/NativeWindow11WinRT.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/NativeWindow11WinRT.cpp
@@ -120,10 +120,12 @@ bool NativeWindow11WinRT::IsValidNativeWindow(EGLNativeWindowType window)
     //
     // ICoreWindow
     // ISwapChainPanel
+    // IDXGISwapChain
     // IPropertySet
     //
     // Anything else will be rejected as an invalid IInspectable.
-    return IsCoreWindow(window) || IsSwapChainPanel(window) || IsEGLConfiguredPropertySet(window);
+    return IsCoreWindow(window) || IsSwapChainPanel(window) || IsSwapChain(window) ||
+           IsEGLConfiguredPropertySet(window);
 }
 
 }  // namespace rx

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/NativeWindow11WinRT.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/NativeWindow11WinRT.cpp
@@ -12,6 +12,7 @@
 #include "libANGLE/renderer/d3d/d3d11/winrt/CoreWindowNativeWindow.h"
 #include "libANGLE/renderer/d3d/d3d11/winrt/InspectableNativeWindow.h"
 #include "libANGLE/renderer/d3d/d3d11/winrt/SwapChainPanelNativeWindow.h"
+#include "libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -43,6 +44,7 @@ bool NativeWindow11WinRT::initialize()
 
     ComPtr<ABI::Windows::UI::Core::ICoreWindow> coreWindow;
     ComPtr<ABI::Windows::UI::Xaml::Controls::ISwapChainPanel> swapChainPanel;
+    ComPtr<IDXGISwapChain> swapChain;
     if (IsCoreWindow(window, &coreWindow))
     {
         mImpl = std::make_shared<CoreWindowNativeWindow>();
@@ -54,6 +56,14 @@ bool NativeWindow11WinRT::initialize()
     else if (IsSwapChainPanel(window, &swapChainPanel))
     {
         mImpl = std::make_shared<SwapChainPanelNativeWindow>();
+        if (mImpl)
+        {
+            return mImpl->initialize(window, propertySet.Get());
+        }
+    }
+    else if (IsSwapChain(window, &swapChain))
+    {
+        mImpl = std::make_shared<SwapChainNativeWindow>();
         if (mImpl)
         {
             return mImpl->initialize(window, propertySet.Get());

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.cpp
@@ -22,6 +22,17 @@ DXGI_FORMAT GetSwapChainFormat(const ComPtr<IDXGISwapChain> &swapChain)
     }
     return DXGI_FORMAT_UNKNOWN;
 }
+
+HRESULT GetSwapChainSize(const ComPtr<IDXGISwapChain> &swapChain, Size *windowSize)
+{
+    DXGI_SWAP_CHAIN_DESC desc = {};
+    HRESULT result            = swapChain->GetDesc(&desc);
+    if (SUCCEEDED(result))
+    {
+        *windowSize = {(float)desc.BufferDesc.Width, (float)desc.BufferDesc.Height};
+    }
+    return result;
+}
 }  // namespace
 
 namespace rx
@@ -76,16 +87,5 @@ HRESULT SwapChainNativeWindow::createSwapChain(ID3D11Device *device,
 HRESULT SwapChainNativeWindow::scaleSwapChain(const Size &windowSize, const RECT &clientRect)
 {
     return S_OK;
-}
-
-HRESULT GetSwapChainSize(const ComPtr<IDXGISwapChain> &swapChain, Size *windowSize)
-{
-    DXGI_SWAP_CHAIN_DESC desc = {};
-    HRESULT result            = swapChain->GetDesc(&desc);
-    if (SUCCEEDED(result))
-    {
-        *windowSize = {(float)desc.BufferDesc.Width, (float)desc.BufferDesc.Height};
-    }
-    return result;
 }
 }  // namespace rx

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.cpp
@@ -1,0 +1,182 @@
+//
+// Copyright 2014 The ANGLE Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+
+// SwapChainNativeWindow.cpp: NativeWindow for managing IDXGISwapChain native window types.
+
+#include "libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.h"
+
+#include <math.h>
+#include <algorithm>
+
+using namespace ABI::Windows::Foundation::Collections;
+using namespace Microsoft::WRL;
+
+namespace
+{
+DXGI_FORMAT GetSwapChainFormat(const ComPtr<IDXGISwapChain> &swapChain)
+{
+    DXGI_SWAP_CHAIN_DESC desc = {};
+    HRESULT result            = swapChain->GetDesc(&desc);
+    if (SUCCEEDED(result))
+    {
+        return desc.BufferDesc.Format;
+    }
+    return DXGI_FORMAT_UNKNOWN;
+}
+}  // namespace
+
+namespace rx
+{
+bool SwapChainNativeWindow::initialize(EGLNativeWindowType window, IPropertySet *propertySet)
+{
+    mSupportsSwapChainResize = false;
+
+    ComPtr<IPropertySet> props = propertySet;
+    ComPtr<IInspectable> win   = window;
+    SIZE swapChainSize         = {};
+    HRESULT result             = S_OK;
+
+    // IPropertySet is an optional parameter and can be null.
+    // If one is specified, cache as an IMap and read the properties
+    // used for initial host initialization.
+    if (propertySet)
+    {
+        result = props.As(&mPropertyMap);
+        if (FAILED(result))
+        {
+            return false;
+        }
+
+        // The EGLRenderSurfaceSizeProperty is optional and may be missing. The IPropertySet
+        // was prevalidated to contain the EGLNativeWindowType before being passed to
+        // this host.
+        result = GetOptionalSizePropertyValue(mPropertyMap, EGLRenderSurfaceSizeProperty,
+                                              &swapChainSize, &mSwapChainSizeSpecified);
+        if (FAILED(result))
+        {
+            return false;
+        }
+
+        // The EGLRenderResolutionScaleProperty is optional and may be missing. The IPropertySet
+        // was prevalidated to contain the EGLNativeWindowType before being passed to
+        // this host.
+        result = GetOptionalSinglePropertyValue(mPropertyMap, EGLRenderResolutionScaleProperty,
+                                                &mSwapChainScale, &mSwapChainScaleSpecified);
+        if (FAILED(result))
+        {
+            return false;
+        }
+
+        if (!mSwapChainScaleSpecified)
+        {
+            // Default value for the scale is 1.0f
+            mSwapChainScale = 1.0f;
+        }
+
+        // A EGLRenderSurfaceSizeProperty and a EGLRenderResolutionScaleProperty can't both be
+        // specified
+        if (mSwapChainScaleSpecified && mSwapChainSizeSpecified)
+        {
+            ERR() << "It is invalid to specify both an EGLRenderSurfaceSizeProperty and a "
+                     "EGLRenderResolutionScaleProperty.";
+            return false;
+        }
+    }
+
+    if (SUCCEEDED(result))
+    {
+        result = win.As(&mSwapChain);
+    }
+
+    if (SUCCEEDED(result))
+    {
+        // If a swapchain size is specfied, then the automatic resize
+        // behaviors implemented by the host should be disabled.  The swapchain
+        // will be still be scaled when being rendered to fit the bounds
+        // of the host.
+        // Scaling of the swapchain output is handled by the EGL client.
+        if (mSwapChainSizeSpecified)
+        {
+            mClientRect = {0, 0, swapChainSize.cx, swapChainSize.cy};
+        }
+        else
+        {
+            Size swapChainPanelSize;
+            result = GetSwapChainSize(mSwapChain, &swapChainPanelSize);
+
+            if (SUCCEEDED(result))
+            {
+                // Update the client rect to account for any swapchain scale factor
+                mClientRect = clientRect(swapChainPanelSize);
+            }
+        }
+    }
+
+    if (SUCCEEDED(result))
+    {
+        mNewClientRect     = mClientRect;
+        mClientRectChanged = false;
+        return true;
+    }
+
+    return false;
+}
+
+HRESULT SwapChainNativeWindow::createSwapChain(ID3D11Device *device,
+                                               IDXGIFactory2 *factory,
+                                               DXGI_FORMAT format,
+                                               unsigned int width,
+                                               unsigned int height,
+                                               bool containsAlpha,
+                                               IDXGISwapChain1 **swapChain)
+{
+    if (swapChain == nullptr || width == 0 || height == 0)
+    {
+        return E_INVALIDARG;
+    }
+    ASSERT(format == GetSwapChainFormat(mSwapChain));
+
+    HRESULT result = mSwapChain.CopyTo(swapChain);
+
+    // If the host is responsible for scaling the output of the swapchain, then
+    // scale it now before returning an instance to the caller.  This is done by
+    // first reading the current size of the swapchain panel, then scaling
+    if (SUCCEEDED(result))
+    {
+        if (mSwapChainSizeSpecified || mSwapChainScaleSpecified)
+        {
+            Size currentPanelSize = {};
+            result                = GetSwapChainSize(mSwapChain, &currentPanelSize);
+
+            // Scale the swapchain to fit inside the contents of the panel.
+            if (SUCCEEDED(result))
+            {
+                ASSERT(width == (unsigned int)currentPanelSize.Width);
+                ASSERT(height == (unsigned int)currentPanelSize.Height);
+                result = scaleSwapChain(currentPanelSize, mClientRect);
+            }
+        }
+    }
+
+    return result;
+}
+
+HRESULT SwapChainNativeWindow::scaleSwapChain(const Size &windowSize, const RECT &clientRect)
+{
+    return S_OK;
+}
+
+HRESULT GetSwapChainSize(const ComPtr<IDXGISwapChain> &swapChain, Size *windowSize)
+{
+    DXGI_SWAP_CHAIN_DESC desc = {};
+    HRESULT result            = swapChain->GetDesc(&desc);
+    if (SUCCEEDED(result))
+    {
+        *windowSize = {(float)desc.BufferDesc.Width, (float)desc.BufferDesc.Height};
+    }
+    return result;
+}
+}  // namespace rx

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.cpp
@@ -8,10 +8,6 @@
 
 #include "libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.h"
 
-#include <math.h>
-#include <algorithm>
-
-using namespace ABI::Windows::Foundation::Collections;
 using namespace Microsoft::WRL;
 
 namespace
@@ -33,85 +29,20 @@ namespace rx
 bool SwapChainNativeWindow::initialize(EGLNativeWindowType window, IPropertySet *propertySet)
 {
     mSupportsSwapChainResize = false;
+    mSwapChainScale          = 1.0f;
 
-    ComPtr<IPropertySet> props = propertySet;
-    ComPtr<IInspectable> win   = window;
-    SIZE swapChainSize         = {};
-    HRESULT result             = S_OK;
-
-    // IPropertySet is an optional parameter and can be null.
-    // If one is specified, cache as an IMap and read the properties
-    // used for initial host initialization.
-    if (propertySet)
-    {
-        result = props.As(&mPropertyMap);
-        if (FAILED(result))
-        {
-            return false;
-        }
-
-        // The EGLRenderSurfaceSizeProperty is optional and may be missing. The IPropertySet
-        // was prevalidated to contain the EGLNativeWindowType before being passed to
-        // this host.
-        result = GetOptionalSizePropertyValue(mPropertyMap, EGLRenderSurfaceSizeProperty,
-                                              &swapChainSize, &mSwapChainSizeSpecified);
-        if (FAILED(result))
-        {
-            return false;
-        }
-
-        // The EGLRenderResolutionScaleProperty is optional and may be missing. The IPropertySet
-        // was prevalidated to contain the EGLNativeWindowType before being passed to
-        // this host.
-        result = GetOptionalSinglePropertyValue(mPropertyMap, EGLRenderResolutionScaleProperty,
-                                                &mSwapChainScale, &mSwapChainScaleSpecified);
-        if (FAILED(result))
-        {
-            return false;
-        }
-
-        if (!mSwapChainScaleSpecified)
-        {
-            // Default value for the scale is 1.0f
-            mSwapChainScale = 1.0f;
-        }
-
-        // A EGLRenderSurfaceSizeProperty and a EGLRenderResolutionScaleProperty can't both be
-        // specified
-        if (mSwapChainScaleSpecified && mSwapChainSizeSpecified)
-        {
-            ERR() << "It is invalid to specify both an EGLRenderSurfaceSizeProperty and a "
-                     "EGLRenderResolutionScaleProperty.";
-            return false;
-        }
-    }
+    ComPtr<IInspectable> win = window;
+    HRESULT result           = win.As(&mSwapChain);
 
     if (SUCCEEDED(result))
     {
-        result = win.As(&mSwapChain);
-    }
+        Size swapChainSize;
+        result = GetSwapChainSize(mSwapChain, &swapChainSize);
 
-    if (SUCCEEDED(result))
-    {
-        // If a swapchain size is specfied, then the automatic resize
-        // behaviors implemented by the host should be disabled.  The swapchain
-        // will be still be scaled when being rendered to fit the bounds
-        // of the host.
-        // Scaling of the swapchain output is handled by the EGL client.
-        if (mSwapChainSizeSpecified)
+        if (SUCCEEDED(result))
         {
-            mClientRect = {0, 0, swapChainSize.cx, swapChainSize.cy};
-        }
-        else
-        {
-            Size swapChainPanelSize;
-            result = GetSwapChainSize(mSwapChain, &swapChainPanelSize);
-
-            if (SUCCEEDED(result))
-            {
-                // Update the client rect to account for any swapchain scale factor
-                mClientRect = clientRect(swapChainPanelSize);
-            }
+            // Update the client rect to account for any swapchain scale factor
+            mClientRect = clientRect(swapChainSize);
         }
     }
 
@@ -139,29 +70,7 @@ HRESULT SwapChainNativeWindow::createSwapChain(ID3D11Device *device,
     }
     ASSERT(format == GetSwapChainFormat(mSwapChain));
 
-    HRESULT result = mSwapChain.CopyTo(swapChain);
-
-    // If the host is responsible for scaling the output of the swapchain, then
-    // scale it now before returning an instance to the caller.  This is done by
-    // first reading the current size of the swapchain panel, then scaling
-    if (SUCCEEDED(result))
-    {
-        if (mSwapChainSizeSpecified || mSwapChainScaleSpecified)
-        {
-            Size currentPanelSize = {};
-            result                = GetSwapChainSize(mSwapChain, &currentPanelSize);
-
-            // Scale the swapchain to fit inside the contents of the panel.
-            if (SUCCEEDED(result))
-            {
-                ASSERT(width == (unsigned int)currentPanelSize.Width);
-                ASSERT(height == (unsigned int)currentPanelSize.Height);
-                result = scaleSwapChain(currentPanelSize, mClientRect);
-            }
-        }
-    }
-
-    return result;
+    return mSwapChain.CopyTo(swapChain);
 }
 
 HRESULT SwapChainNativeWindow::scaleSwapChain(const Size &windowSize, const RECT &clientRect)

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.cpp
@@ -64,11 +64,11 @@ HRESULT SwapChainNativeWindow::createSwapChain(ID3D11Device *device,
                                                bool containsAlpha,
                                                IDXGISwapChain1 **swapChain)
 {
-    if (swapChain == nullptr || width == 0 || height == 0)
+    if (swapChain == nullptr || width == 0 || height == 0 ||
+        format != GetSwapChainFormat(mSwapChain))
     {
         return E_INVALIDARG;
     }
-    ASSERT(format == GetSwapChainFormat(mSwapChain));
 
     return mSwapChain.CopyTo(swapChain);
 }

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.h
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.h
@@ -35,7 +35,5 @@ class SwapChainNativeWindow : public InspectableNativeWindow,
     ComPtr<IMap<HSTRING, IInspectable *>> mPropertyMap;
     ComPtr<IDXGISwapChain> mSwapChain;
 };
-
-HRESULT GetSwapChainSize(const ComPtr<IDXGISwapChain> &swapChain, Size *windowSize);
 }  // namespace rx
 #endif  // LIBANGLE_RENDERER_D3D_D3D11_WINRT_SWAPCHAINPANELNATIVEWINDOW_H_

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.h
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainNativeWindow.h
@@ -1,0 +1,41 @@
+//
+// Copyright 2014 The ANGLE Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+
+// SwapChainNativeWindow.h: NativeWindow for managing IDXGISwapChain native window types.
+
+#ifndef LIBANGLE_RENDERER_D3D_D3D11_WINRT_SWAPCHAINNATIVEWINDOW_H_
+#define LIBANGLE_RENDERER_D3D_D3D11_WINRT_SWAPCHAINNATIVEWINDOW_H_
+
+#include "libANGLE/renderer/d3d/d3d11/winrt/InspectableNativeWindow.h"
+
+#include <memory>
+
+namespace rx
+{
+class SwapChainNativeWindow : public InspectableNativeWindow,
+                              public std::enable_shared_from_this<SwapChainNativeWindow>
+{
+  public:
+    bool initialize(EGLNativeWindowType window, IPropertySet *propertySet) override;
+    HRESULT createSwapChain(ID3D11Device *device,
+                            IDXGIFactory2 *factory,
+                            DXGI_FORMAT format,
+                            unsigned int width,
+                            unsigned int height,
+                            bool containsAlpha,
+                            IDXGISwapChain1 **swapChain) override;
+
+  protected:
+    HRESULT scaleSwapChain(const Size &windowSize, const RECT &clientRect) override;
+
+  private:
+    ComPtr<IMap<HSTRING, IInspectable *>> mPropertyMap;
+    ComPtr<IDXGISwapChain> mSwapChain;
+};
+
+HRESULT GetSwapChainSize(const ComPtr<IDXGISwapChain> &swapChain, Size *windowSize);
+}  // namespace rx
+#endif  // LIBANGLE_RENDERER_D3D_D3D11_WINRT_SWAPCHAINPANELNATIVEWINDOW_H_


### PR DESCRIPTION
We have a swapchain in Shapr3D that we create with certain flags (see [doc](https://shapr3d.atlassian.net/wiki/spaces/DD/pages/2575237420/Tuning+DirectX+Swap+Chains)) and this commit allows passing it to EGL. It was partly based on how EGL accepts [SwapChainPanels](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.swapchainpanel?view=winrt-22000) (UWP UI control for rendering into a surface in a XAML hierarchy).

The commits self-document the necessary changes. Only D3D11 backend was changed.

For testing purposes, I recommend using the branch `GFX-591_ALL`.

### Note
I actually found a typo in [MSDN doc](https://docs.microsoft.com/en-us/windows/win32/api/dxgi1_2/ns-dxgi1_2-dxgi_present_parameters#remarks). The forbidden swap effects for partial presentation are the discarding ones (as documented in another [MSDN doc](https://docs.microsoft.com/en-us/windows/win32/api/dxgi/ne-dxgi-dxgi_swap_effect#constants))