### PR TITLE
[GFX-1593] Do wait for GPU when mapping GPU buffers to CPU

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -1466,10 +1466,8 @@ angle::Result Buffer11::NativeStorage::map(const gl::Context *context,
 
     D3D11_MAPPED_SUBRESOURCE mappedResource;
     D3D11_MAP d3dMapType = gl_d3d11::GetD3DMapTypeFromBits(mUsage, access);
-    UINT d3dMapFlag = ((access & GL_MAP_UNSYNCHRONIZED_BIT) != 0 ? D3D11_MAP_FLAG_DO_NOT_WAIT : 0);
 
-    ANGLE_TRY(
-        mRenderer->mapResource(context, mBuffer.get(), 0, d3dMapType, d3dMapFlag, &mappedResource));
+    ANGLE_TRY(mRenderer->mapResource(context, mBuffer.get(), 0, d3dMapType, 0, &mappedResource));
     ASSERT(mappedResource.pData);
     *mapPointerOut = static_cast<uint8_t *>(mappedResource.pData) + offset;
     return angle::Result::Continue;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1593](https://shapr3d.atlassian.net/browse/GFX-1593)

## Short description (What? How?) 📖
Read my comment on the Jira card. We have multiple options to tackle the problem, and I chose one that fixes the annoying assert to help debugging in the early stages of Windows renderer development. [GFX-1786](https://shapr3d.atlassian.net/browse/GFX-1786) will do actual measurements and choose the most performant solution (possibly taking care of the annoying assert too, to not hinder debugging).

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Buffer updates in the D3D11 backend

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Checked on my local machine.

Automated 💻
n/a