### PR TITLE
[GFX-1796] Fix storage dimension mismatch after chosing new base level of NPOT texture (D3D9/11)

### DIFF
--- a/src/libANGLE/renderer/d3d/TextureD3D.cpp
+++ b/src/libANGLE/renderer/d3d/TextureD3D.cpp
@@ -651,21 +651,28 @@ angle::Result TextureD3D::getAttachmentRenderTarget(const gl::Context *context,
 
 angle::Result TextureD3D::setBaseLevel(const gl::Context *context, GLuint baseLevel)
 {
-    const int oldStorageWidth  = std::max(1, getLevelZeroWidth());
-    const int oldStorageHeight = std::max(1, getLevelZeroHeight());
-    const int oldStorageDepth  = std::max(1, getLevelZeroDepth());
-    const int oldStorageFormat = getBaseLevelInternalFormat();
-    mBaseLevel                 = baseLevel;
+    if (!mTexStorage)
+    {
+        mBaseLevel = baseLevel;
+        return angle::Result::Continue;
+    }
 
     // When the base level changes, the texture storage might not be valid anymore, since it could
     // have been created based on the dimensions of the previous specified level range.
-    const int newStorageWidth  = std::max(1, getLevelZeroWidth());
-    const int newStorageHeight = std::max(1, getLevelZeroHeight());
-    const int newStorageDepth  = std::max(1, getLevelZeroDepth());
-    const int newStorageFormat = getBaseLevelInternalFormat();
-    if (mTexStorage &&
-        (newStorageWidth != oldStorageWidth || newStorageHeight != oldStorageHeight ||
-         newStorageDepth != oldStorageDepth || newStorageFormat != oldStorageFormat))
+    const int oldFormat = getBaseLevelInternalFormat();
+    mBaseLevel          = baseLevel;
+    const int newFormat = getBaseLevelInternalFormat();
+
+    const int storageWidth  = mTexStorage->getLevelWidth(baseLevel);
+    const int storageHeight = mTexStorage->getLevelHeight(baseLevel);
+    const int storageDepth  = mTexStorage->getLevelDepth(baseLevel);
+
+    const int imageWidth  = std::max(1, getBaseLevelWidth());
+    const int imageHeight = std::max(1, getBaseLevelHeight());
+    const int imageDepth  = std::max(1, getBaseLevelDepth());
+
+    if (storageWidth != imageWidth || storageHeight != imageHeight || storageDepth != imageDepth ||
+        oldFormat != newFormat)
     {
         markAllImagesDirty();
 

--- a/src/libANGLE/renderer/d3d/TextureStorage.h
+++ b/src/libANGLE/renderer/d3d/TextureStorage.h
@@ -50,6 +50,9 @@ class TextureStorage : public angle::Subject
     virtual bool isManaged() const                    = 0;
     virtual bool supportsNativeMipmapFunction() const = 0;
     virtual int getLevelCount() const                 = 0;
+    virtual int getLevelWidth(int mipLevel) const     = 0;
+    virtual int getLevelHeight(int mipLevel) const    = 0;
+    virtual int getLevelDepth(int mipLevel) const     = 0;
 
     virtual angle::Result findRenderTarget(const gl::Context *context,
                                            const gl::ImageIndex &index,

--- a/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.h
@@ -104,6 +104,10 @@ class TextureStorage11 : public TextureStorage
     bool isManaged() const override;
     bool supportsNativeMipmapFunction() const override;
     int getLevelCount() const override;
+    int getLevelWidth(int mipLevel) const override;
+    int getLevelHeight(int mipLevel) const override;
+    int getLevelDepth(int mipLevel) const override;
+
     angle::Result generateMipmap(const gl::Context *context,
                                  const gl::ImageIndex &sourceIndex,
                                  const gl::ImageIndex &destIndex) override;
@@ -148,9 +152,6 @@ class TextureStorage11 : public TextureStorage
                      UINT miscFlags,
                      GLenum internalFormat,
                      const std::string &label);
-    int getLevelWidth(int mipLevel) const;
-    int getLevelHeight(int mipLevel) const;
-    int getLevelDepth(int mipLevel) const;
 
     // Some classes (e.g. TextureStorage11_2D) will override getMippedResource.
     virtual angle::Result getMippedResource(const gl::Context *context,

--- a/src/libANGLE/renderer/d3d/d3d9/TextureStorage9.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/TextureStorage9.cpp
@@ -92,6 +92,20 @@ int TextureStorage9::getLevelCount() const
     return static_cast<int>(mMipLevels) - mTopLevel;
 }
 
+int TextureStorage9::getLevelWidth(int mipLevel) const
+{
+    return std::max(static_cast<int>(mTextureWidth) >> mipLevel, 1);
+}
+
+int TextureStorage9::getLevelHeight(int mipLevel) const
+{
+    return std::max(static_cast<int>(mTextureHeight) >> mipLevel, 1);
+}
+int TextureStorage9::getLevelDepth(int mipLevel) const
+{
+    return 1;
+}
+
 angle::Result TextureStorage9::setData(const gl::Context *context,
                                        const gl::ImageIndex &index,
                                        ImageD3D *image,

--- a/src/libANGLE/renderer/d3d/d3d9/TextureStorage9.h
+++ b/src/libANGLE/renderer/d3d/d3d9/TextureStorage9.h
@@ -45,6 +45,9 @@ class TextureStorage9 : public TextureStorage
     bool isManaged() const override;
     bool supportsNativeMipmapFunction() const override;
     int getLevelCount() const override;
+    int getLevelWidth(int mipLevel) const override;
+    int getLevelHeight(int mipLevel) const override;
+    int getLevelDepth(int mipLevel) const override;
 
     angle::Result setData(const gl::Context *context,
                           const gl::ImageIndex &index,


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1796](https://shapr3d.atlassian.net/browse/GFX-1796)

## Short description (What? How?) 📖
This PR changes calculation of internal texture storage dimensions - which concerns mipmapped textures (incl. arrays and cubes) - in order to avoid storage reallocation in non-power-of-two textures following a base level update.

Repro steps of the issue:
- Create a 2D texture with 255x255 pixels on level 0.
- Allocate storage for its entire mip chain.
- Change its base level to 1.

At this point, our `TextureD3D` object decides that a new a storage is needed with 254x254 at level 0, and a copy operation is triggered from the old to the new image.

The reason for the mismatch in our example was that storage dimensions were extrapolated from base level texture dimensions (using a left-shift). As proposed here, we can instead query the existing storage dimension.

## Testing

### Affected areas 🧭
Texture storage allocation.

### Special use-cases to test 🧷
Any sequence of calls to GL functions mutating storage of a texture (`glTexStorage2D()`, `glTexImage2D()`, `glTexSubImage2D()`, `glGenerateMipmap()`), and modifying the base level.

### How did you test it? 🤔
Manual 💁‍♂️
Tested on the repro above.

Automated 💻
Ran `angle_end2end_tests` target, which has several of test cases covering specifying a texture's base level and mutating its storage.