### PR TITLE
[GFX-1854] Fix log message spamming

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/StateManager11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/StateManager11.cpp
@@ -270,7 +270,7 @@ void StateManager11::ViewCache<ViewType, DescType>::update(size_t resourceIndex,
             do
             {
                 --mHighestUsedView;
-            } while (mHighestUsedView > 0 && mCurrentViews[mHighestUsedView].view == 0);
+            } while (mHighestUsedView > 0 && mCurrentViews[mHighestUsedView - 1].view == 0);
         }
     }
 }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1854](https://shapr3d.atlassian.net/browse/GFX-1854)

## Short description (What? How?) 📖

ANGLE spams the Output window in Debug mode with these warnings:

```
D3D11 WARNING: ID3D11DeviceContext::OMSetRenderTargets: Resource being set to OM RenderTarget slot 0 is still bound on input! [ STATE_SETTING WARNING #9: DEVICE_OMSETRENDERTARGETS_HAZARD]
D3D11 WARNING: ID3D11DeviceContext::OMSetRenderTargets[AndUnorderedAccessViews]: Forcing PS shader resource slot 10 to NULL. [ STATE_SETTING WARNING #7: DEVICE_PSSETSHADERRESOURCES_HAZARD]
```

These are false positives, because before the actual draw call sent to execution the RenderTarget will be changed. ANGLE already have functionality to disable these warnings by unbinding the RTVs before other operations, but due to improper caching this doesn't happen in this case.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
StateManager, Debug mode

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Run Shapr3D app with debug ANGLE and then checked in Visualization tool, the messages disappeared from the Output window.

Automated 💻
n/a