### PR TITLE
[GFX-594] Buffer11 takes ownership of external buffer

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -405,7 +405,8 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
         updateD3DBufferUsage(context, gl::BufferUsage::DynamicDraw);
 
         auto *contextD3D     = GetImplAs<ContextD3D>(context);
-        auto *clientBuffer11 = static_cast<ID3D11Buffer *>(clientBuffer);
+        d3d11::Buffer buffer(d3d11::DynamicCastComObject<ID3D11Buffer>(static_cast<IUnknown *>(clientBuffer)), nullptr);
+        auto* clientBuffer11 = buffer.get();
 
         D3D11_BUFFER_DESC clientBufferDesc11;
         clientBuffer11->GetDesc(&clientBufferDesc11);
@@ -461,7 +462,6 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
                 ANGLE_CHECK(contextD3D, false, "Unsupported target", GL_INVALID_OPERATION);
         }
 
-        d3d11::Buffer buffer(clientBuffer11, nullptr);
         BufferStorage *storage = new NativeStorage(mRenderer, bufferUsage, nullptr, &buffer, size);
         onStorageUpdate(storage);
         mBufferStorages[bufferUsage] = storage;

--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -406,7 +406,7 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
 
         auto *contextD3D     = GetImplAs<ContextD3D>(context);
         d3d11::Buffer buffer(d3d11::DynamicCastComObject<ID3D11Buffer>(static_cast<IUnknown *>(clientBuffer)), nullptr);
-        auto* clientBuffer11 = buffer.get();
+        auto *clientBuffer11 = buffer.get();
 
         D3D11_BUFFER_DESC clientBufferDesc11;
         clientBuffer11->GetDesc(&clientBufferDesc11);


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-594](https://shapr3d.atlassian.net/browse/GFX-594)

## Short description (What? How?) 📖
In our external buffer extension the user had to increase the reference count of the `D3D11Resource`, before it was passed to the function. `ANGLE` follows a different convention it increases the reference count by itself, so we revisited our approach and changed it to `ANGLE`'s way of doing.

Note: `d3d11::Buffer` is an alias for `Resource11<ID3D11Buffer>` (it is defined at https://github.com/shapr3d/angle/blob/shapr_master/src/libANGLE/renderer/d3d/d3d11/ResourceManager11.h#L402 with macro magic ✨). This type is a RAII class, which will call `Release()`, when the object destructed.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
External buffer reference counting

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Checked with Shapr3D in Debug mode on Windows after I removed the reference count increment from `Gfx::GetNativeBuffer()`. 

Automated 💻
n/a