### PR TITLE
[GFX-2005] External buffer storage is StaticDraw by default (D3D11)

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -402,6 +402,8 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
         // calling BufferStorage() (and as consequence BufferStorageExternal())
         // modifies the buffer object state such that BUFFER_USAGE is set to
         // DYNAMIC_DRAW.
+        // Going against the spec, we choose STATIC_DRAW as a workaround aiming 
+        // to avoid staging and system memory copies.
         updateD3DBufferUsage(context, gl::BufferUsage::StaticDraw);
 
         auto *contextD3D     = GetImplAs<ContextD3D>(context);

--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -402,7 +402,7 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
         // calling BufferStorage() (and as consequence BufferStorageExternal())
         // modifies the buffer object state such that BUFFER_USAGE is set to
         // DYNAMIC_DRAW.
-        updateD3DBufferUsage(context, gl::BufferUsage::DynamicDraw);
+        updateD3DBufferUsage(context, gl::BufferUsage::StaticDraw);
 
         auto *contextD3D     = GetImplAs<ContextD3D>(context);
         d3d11::Buffer buffer(d3d11::DynamicCastComObject<ID3D11Buffer>(static_cast<IUnknown *>(clientBuffer)), nullptr);


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2005](https://shapr3d.atlassian.net/browse/)

## Short description (What? How?) 📖
Changing usage flag for external buffer storage from `DynamicDraw` to `StaticDraw`. This knowingly goes against the spec of `EXT_buffer_storage`, and it should be treated as a workaround.

In the case of `BufferUsage::DynamicDraw`, ANGLE - assuming buffer contents change every frame - creates copies that can get out of sync whenever the external buffer is updated outside ANGLE. Our app cannot yet initiate the necessary synchronization at such events. With the current usage patterns of these buffers in our app, `BufferUsage::StaticDraw` works without any copies. For more details, see app side PR: https://github.com/shapr3d/shapr3d/pull/11738.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
External buffers (D3D11)

### Special use-cases to test 🧷
Missed synchronization. Buffer sizes much larger than read amount.

### How did you test it? 🤔
Manual 💁‍♂️
Shapr3D Visualization.
