### PR TITLE
[GFX-2068] Revert external buffer storage to DynamicDraw

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -402,9 +402,7 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
         // calling BufferStorage() (and as consequence BufferStorageExternal())
         // modifies the buffer object state such that BUFFER_USAGE is set to
         // DYNAMIC_DRAW.
-        // Going against the spec, we choose STATIC_DRAW as a workaround aiming 
-        // to avoid staging and system memory copies.
-        updateD3DBufferUsage(context, gl::BufferUsage::StaticDraw);
+        updateD3DBufferUsage(context, gl::BufferUsage::DynamicDraw);
 
         auto *contextD3D     = GetImplAs<ContextD3D>(context);
         d3d11::Buffer buffer(d3d11::DynamicCastComObject<ID3D11Buffer>(static_cast<IUnknown *>(clientBuffer)), nullptr);


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2068](https://shapr3d.atlassian.net/browse/GFX-2068)

## Short description (What? How?) 📖
Revert the temporary StaticDraw change which was introduced to external buffer storage in https://github.com/shapr3d/angle/pull/18.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
External buffer importing

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Same as https://github.com/shapr3d/angle/pull/18

Automated 💻
n/a