### PR TITLE
[GFX-1975] Don't overwrite existing debug name (D3D11)

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -2345,6 +2345,15 @@ HRESULT SetDebugName(ID3D11DeviceChild *resource,
                      const char *internalName,
                      const std::string *khrDebugName)
 {
+    UINT debugNameSize = 0;
+    HRESULT result = resource->GetPrivateData(WKPDID_D3DDebugObjectName, &debugNameSize, nullptr);
+
+    // If the resource already has a name, don't overwrite it.
+    if (debugNameSize > 0)
+    {
+        return result;
+    }
+
     // Prepend ANGLE to separate names from other components in the same process.
     std::string d3dName = "ANGLE";
     bool sendNameToD3D  = false;

--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -2345,35 +2345,35 @@ HRESULT SetDebugName(ID3D11DeviceChild *resource,
                      const char *internalName,
                      const std::string *khrDebugName)
 {
-    UINT debugNameSize = 0;
+    const bool hasInternalName = (internalName && internalName[0] != '\0');
+    const bool hasKhrDebugName = (khrDebugName && !khrDebugName->empty());
+
+    if (!hasInternalName && !hasKhrDebugName)
+    {
+        return S_OK;
+    }
+
+    UINT debugNameSize;
     HRESULT result = resource->GetPrivateData(WKPDID_D3DDebugObjectName, &debugNameSize, nullptr);
 
     // If the resource already has a name, don't overwrite it.
-    if (debugNameSize > 0)
+    if (result != DXGI_ERROR_NOT_FOUND)
     {
         return result;
     }
 
     // Prepend ANGLE to separate names from other components in the same process.
     std::string d3dName = "ANGLE";
-    bool sendNameToD3D  = false;
-    if (internalName && internalName[0] != '\0')
+    if (hasInternalName)
     {
         d3dName += std::string("_") + internalName;
-        sendNameToD3D = true;
     }
-    if (khrDebugName && !khrDebugName->empty())
+    if (hasKhrDebugName)
     {
         d3dName += std::string("_") + *khrDebugName;
-        sendNameToD3D = true;
     }
-    // If both internalName and khrDebugName are empty, avoid sending the string to d3d.
-    if (sendNameToD3D)
-    {
-        return resource->SetPrivateData(WKPDID_D3DDebugObjectName,
-                                        static_cast<UINT>(d3dName.size()), d3dName.c_str());
-    }
-    return S_OK;
+    return resource->SetPrivateData(WKPDID_D3DDebugObjectName, static_cast<UINT>(d3dName.size()),
+                                    d3dName.c_str());
 }
 
 // Keep this in cpp file where it has visibility of Renderer11.h, otherwise calling


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1975](https://shapr3d.atlassian.net/browse/GFX-1975)

## Short description (What? How?) 📖
The goal of this PR is to prevent a D3D11 validation layer warnings when ANGLE uses an external D3D11 device via the `EGL_ANGLE_device_d3d` extension.
```
D3D11 WARNING: ID3D11RasterizerState2::SetPrivateData: Existing private data of same name with different size found! 
[ STATE_SETTING WARNING #55: SETPRIVATEDATA_CHANGINGPARAMS]
```
Because the D3D11 runtime caches rasterizer, depth-stencil, and blend states objects, debug names of the host application and those provided by ANGLE may conflict. Our solution is to keep the name originally set by the application.

### Affected areas 🧭
Debug names in frame capture tools like VSGA, PIX.

## Testing

### How did you test it? 🤔
Manual 💁‍♂️
Created a frame capture in VSGA and verified that debug names are still there.

[GFX-1975]: https://shapr3d.atlassian.net/browse/GFX-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ