### PR TITLE
[GFX-2502] Revert external buffer storage to DynamicDraw (#19)

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Buffer11.cpp
@@ -402,7 +402,9 @@ angle::Result Buffer11::setDataWithUsageFlags(const gl::Context *context,
         // calling BufferStorage() (and as consequence BufferStorageExternal())
         // modifies the buffer object state such that BUFFER_USAGE is set to
         // DYNAMIC_DRAW.
-        updateD3DBufferUsage(context, gl::BufferUsage::DynamicDraw);
+        // Going against the spec, we choose STATIC_DRAW as a workaround aiming 
+        // to avoid staging and system memory copies.
+        updateD3DBufferUsage(context, gl::BufferUsage::StaticDraw);
 
         auto *contextD3D     = GetImplAs<ContextD3D>(context);
         d3d11::Buffer buffer(d3d11::DynamicCastComObject<ID3D11Buffer>(static_cast<IUnknown *>(clientBuffer)), nullptr);


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2502](https://shapr3d.atlassian.net/browse/GFX-2502)

## Short description (What? How?) 📖
We are in need of this patch again to ship a performant PBR renderer on Window too (https://github.com/shapr3d/shapr3d/pull/14719).

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
n/a

Automated 💻
n/a

[GFX-2502]: https://shapr3d.atlassian.net/browse/GFX-2502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ