### PR TITLE
[GFX-5240] Implement EXT_EGL_image_storage in D3D11

### DIFF
--- a/src/libANGLE/Texture.cpp
+++ b/src/libANGLE/Texture.cpp
@@ -1952,7 +1952,7 @@ angle::Result Texture::setEGLImageTargetImpl(Context *context,
                              initState);
     mState.mHasProtectedContent = imageTarget->hasProtectedContent();
 
-    ANGLE_TRY(mTexture->setEGLImageTarget(context, type, imageTarget));
+    ANGLE_TRY(mTexture->setEGLImageTarget(context, type, levels, imageTarget));
 
     signalDirtyStorage(initState);
 

--- a/src/libANGLE/renderer/TextureImpl.h
+++ b/src/libANGLE/renderer/TextureImpl.h
@@ -194,6 +194,7 @@ class TextureImpl : public FramebufferAttachmentObjectImpl
 
     virtual angle::Result setEGLImageTarget(const gl::Context *context,
                                             gl::TextureType type,
+                                            GLuint levels,
                                             egl::Image *image) = 0;
 
     virtual angle::Result setImageExternal(const gl::Context *context,

--- a/src/libANGLE/renderer/d3d/RendererD3D.h
+++ b/src/libANGLE/renderer/d3d/RendererD3D.h
@@ -328,6 +328,7 @@ class RendererD3D : public BufferFactoryD3D
                                                    const std::string &label)           = 0;
     virtual TextureStorage *createTextureStorageEGLImage(EGLImageD3D *eglImage,
                                                          RenderTargetD3D *renderTargetD3D,
+                                                         GLuint levels,
                                                          const std::string &label)     = 0;
     virtual TextureStorage *createTextureStorageBuffer(
         const gl::OffsetBindingPointer<gl::Buffer> &buffer,

--- a/src/libANGLE/renderer/d3d/TextureD3D.cpp
+++ b/src/libANGLE/renderer/d3d/TextureD3D.cpp
@@ -1436,17 +1436,23 @@ angle::Result TextureD3D_2D::releaseTexImage(const gl::Context *context)
 
 angle::Result TextureD3D_2D::setEGLImageTarget(const gl::Context *context,
                                                gl::TextureType type,
+                                               GLuint levels,
                                                egl::Image *image)
 {
     EGLImageD3D *eglImaged3d = GetImplAs<EGLImageD3D>(image);
 
-    // Set the properties of the base mip level from the EGL image
+    // Mirror the per-level setup that setStorage() performs so that mImageArray reflects every
+    // mip level the EGLImage actually owns. Necessary for glEGLImageTargetTexStorageEXT to expose
+    // a full mip chain; the legacy OES single-level entry simply passes levels = 1.
     const auto &format = image->getFormat();
-    gl::Extents size(static_cast<int>(image->getWidth()), static_cast<int>(image->getHeight()), 1);
-    ANGLE_TRY(redefineImage(context, 0, format.info->sizedInternalFormat, size, true));
-
-    // Clear all other images.
-    for (size_t level = 1; level < mImageArray.size(); level++)
+    const int baseWidth  = static_cast<int>(image->getWidth());
+    const int baseHeight = static_cast<int>(image->getHeight());
+    for (size_t level = 0; level < levels; level++)
+    {
+        gl::Extents levelSize(std::max(1, baseWidth >> level), std::max(1, baseHeight >> level), 1);
+        ANGLE_TRY(redefineImage(context, level, format.info->sizedInternalFormat, levelSize, true));
+    }
+    for (size_t level = levels; level < mImageArray.size(); level++)
     {
         ANGLE_TRY(redefineImage(context, level, GL_NONE, gl::Extents(0, 0, 1), true));
     }
@@ -1458,8 +1464,8 @@ angle::Result TextureD3D_2D::setEGLImageTarget(const gl::Context *context,
     RenderTargetD3D *renderTargetD3D = nullptr;
     ANGLE_TRY(eglImaged3d->getRenderTarget(context, &renderTargetD3D));
 
-    mTexStorage =
-        mRenderer->createTextureStorageEGLImage(eglImaged3d, renderTargetD3D, mState.getLabel());
+    mTexStorage = mRenderer->createTextureStorageEGLImage(eglImaged3d, renderTargetD3D, levels,
+                                                          mState.getLabel());
     mEGLImageTarget = true;
 
     return angle::Result::Continue;
@@ -1818,6 +1824,7 @@ bool TextureD3D_Cube::isSRGB(GLint level, GLint layer) const
 
 angle::Result TextureD3D_Cube::setEGLImageTarget(const gl::Context *context,
                                                  gl::TextureType type,
+                                                 GLuint /*levels*/,
                                                  egl::Image *image)
 {
     ANGLE_HR_UNREACHABLE(GetImplAs<ContextD3D>(context));
@@ -2570,6 +2577,7 @@ bool TextureD3D_3D::isSRGB(GLint level) const
 
 angle::Result TextureD3D_3D::setEGLImageTarget(const gl::Context *context,
                                                gl::TextureType type,
+                                               GLuint /*levels*/,
                                                egl::Image *image)
 {
     ANGLE_HR_UNREACHABLE(GetImplAs<ContextD3D>(context));
@@ -3249,6 +3257,7 @@ bool TextureD3D_2DArray::isSRGB(GLint level) const
 
 angle::Result TextureD3D_2DArray::setEGLImageTarget(const gl::Context *context,
                                                     gl::TextureType type,
+                                                    GLuint /*levels*/,
                                                     egl::Image *image)
 {
     ANGLE_HR_UNREACHABLE(GetImplAs<ContextD3D>(context));
@@ -4102,6 +4111,7 @@ angle::Result TextureD3D_External::setImageExternal(const gl::Context *context,
 
 angle::Result TextureD3D_External::setEGLImageTarget(const gl::Context *context,
                                                      gl::TextureType type,
+                                                     GLuint levels,
                                                      egl::Image *image)
 {
     EGLImageD3D *eglImaged3d = GetImplAs<EGLImageD3D>(image);
@@ -4111,8 +4121,8 @@ angle::Result TextureD3D_External::setEGLImageTarget(const gl::Context *context,
     ANGLE_TRY(eglImaged3d->getRenderTarget(context, &renderTargetD3D));
 
     ANGLE_TRY(releaseTexStorage(context, gl::TexLevelMask()));
-    mTexStorage =
-        mRenderer->createTextureStorageEGLImage(eglImaged3d, renderTargetD3D, mState.getLabel());
+    mTexStorage = mRenderer->createTextureStorageEGLImage(eglImaged3d, renderTargetD3D, levels,
+                                                          mState.getLabel());
 
     return angle::Result::Continue;
 }
@@ -4223,6 +4233,7 @@ angle::Result TextureD3D_2DMultisample::setStorageMultisample(const gl::Context 
 
 angle::Result TextureD3D_2DMultisample::setEGLImageTarget(const gl::Context *context,
                                                           gl::TextureType type,
+                                                          GLuint /*levels*/,
                                                           egl::Image *image)
 {
     ANGLE_HR_UNREACHABLE(GetImplAs<ContextD3D>(context));
@@ -4343,6 +4354,7 @@ angle::Result TextureD3D_2DMultisampleArray::setStorageMultisample(const gl::Con
 
 angle::Result TextureD3D_2DMultisampleArray::setEGLImageTarget(const gl::Context *context,
                                                                gl::TextureType type,
+                                                               GLuint /*levels*/,
                                                                egl::Image *image)
 {
     ANGLE_HR_UNREACHABLE(GetImplAs<ContextD3D>(context));
@@ -4589,6 +4601,7 @@ void TextureD3D_Buffer::markAllImagesDirty()
 
 angle::Result TextureD3D_Buffer::setEGLImageTarget(const gl::Context *context,
                                                    gl::TextureType type,
+                                                   GLuint /*levels*/,
                                                    egl::Image *image)
 {
     ANGLE_HR_UNREACHABLE(GetImplAs<ContextD3D>(context));

--- a/src/libANGLE/renderer/d3d/TextureD3D.h
+++ b/src/libANGLE/renderer/d3d/TextureD3D.h
@@ -314,6 +314,7 @@ class TextureD3D_2D : public TextureD3D
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result getRenderTarget(const gl::Context *context,
@@ -445,6 +446,7 @@ class TextureD3D_Cube : public TextureD3D
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result getRenderTarget(const gl::Context *context,
@@ -579,6 +581,7 @@ class TextureD3D_3D : public TextureD3D
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result getRenderTarget(const gl::Context *context,
@@ -710,6 +713,7 @@ class TextureD3D_2DArray : public TextureD3D
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result getRenderTarget(const gl::Context *context,
@@ -828,6 +832,7 @@ class TextureD3D_External : public TextureD3DImmutableBase
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result getRenderTarget(const gl::Context *context,
@@ -871,6 +876,7 @@ class TextureD3D_2DMultisample : public TextureD3DImmutableBase
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result getRenderTarget(const gl::Context *context,
@@ -917,6 +923,7 @@ class TextureD3D_2DMultisampleArray : public TextureD3DImmutableBase
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result getRenderTarget(const gl::Context *context,
@@ -1009,6 +1016,7 @@ class TextureD3D_Buffer : public TextureD3D
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result getRenderTarget(const gl::Context *context,

--- a/src/libANGLE/renderer/d3d/d3d11/ExternalImageSiblingImpl11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/ExternalImageSiblingImpl11.cpp
@@ -58,6 +58,8 @@ egl::Error ExternalImageSiblingImpl11::initialize(const egl::Display *display)
     D3D11_TEXTURE2D_DESC textureDesc = {};
     texture->GetDesc(&textureDesc);
 
+    mMipLevels = textureDesc.MipLevels;
+
     if (d3d11::IsSupportedMultiplanarFormat(textureDesc.Format))
     {
         if (!mAttribs.contains(EGL_D3D11_TEXTURE_PLANE_ANGLE))
@@ -132,6 +134,11 @@ gl::Extents ExternalImageSiblingImpl11::getSize() const
 size_t ExternalImageSiblingImpl11::getSamples() const
 {
     return mSamples;
+}
+
+uint32_t ExternalImageSiblingImpl11::getLevelCount() const
+{
+    return mMipLevels;
 }
 
 angle::Result ExternalImageSiblingImpl11::getAttachmentRenderTarget(

--- a/src/libANGLE/renderer/d3d/d3d11/ExternalImageSiblingImpl11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/ExternalImageSiblingImpl11.h
@@ -33,6 +33,7 @@ class ExternalImageSiblingImpl11 : public ExternalImageSiblingImpl
     bool hasProtectedContent() const override;
     gl::Extents getSize() const override;
     size_t getSamples() const override;
+    uint32_t getLevelCount() const override;
 
     // FramebufferAttachmentObjectImpl interface
     angle::Result getAttachmentRenderTarget(const gl::Context *context,
@@ -61,6 +62,7 @@ class ExternalImageSiblingImpl11 : public ExternalImageSiblingImpl
     EGLint mHeight       = 0;
     GLsizei mSamples     = 0;
     UINT mArraySlice     = 0;
+    UINT mMipLevels      = 1;
 
     std::unique_ptr<RenderTargetD3D> mRenderTarget;
 };

--- a/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
@@ -3438,10 +3438,11 @@ TextureStorage *Renderer11::createTextureStorage2D(SwapChainD3D *swapChain,
 
 TextureStorage *Renderer11::createTextureStorageEGLImage(EGLImageD3D *eglImage,
                                                          RenderTargetD3D *renderTargetD3D,
+                                                         GLuint levels,
                                                          const std::string &label)
 {
     return new TextureStorage11_EGLImage(this, eglImage, GetAs<RenderTarget11>(renderTargetD3D),
-                                         label);
+                                         levels, label);
 }
 
 TextureStorage *Renderer11::createTextureStorageExternal(

--- a/src/libANGLE/renderer/d3d/d3d11/Renderer11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/Renderer11.h
@@ -243,6 +243,7 @@ class Renderer11 : public RendererD3D
                                            const std::string &label) override;
     TextureStorage *createTextureStorageEGLImage(EGLImageD3D *eglImage,
                                                  RenderTargetD3D *renderTargetD3D,
+                                                 GLuint levels,
                                                  const std::string &label) override;
     TextureStorage *createTextureStorageExternal(egl::Stream *stream,
                                                  const egl::Stream::GLTextureDescription &desc,

--- a/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.cpp
@@ -1916,6 +1916,7 @@ angle::Result TextureStorage11ImmutableBase::createUAVForImage(const gl::Context
 TextureStorage11_EGLImage::TextureStorage11_EGLImage(Renderer11 *renderer,
                                                      EGLImageD3D *eglImage,
                                                      RenderTarget11 *renderTarget11,
+                                                     GLuint levels,
                                                      const std::string &label)
     : TextureStorage11ImmutableBase(renderer,
                                     D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE,
@@ -1930,7 +1931,7 @@ TextureStorage11_EGLImage::TextureStorage11_EGLImage(Renderer11 *renderer,
 {
     mCurrentRenderTarget = reinterpret_cast<uintptr_t>(renderTarget11);
 
-    mMipLevels     = 1;
+    mMipLevels     = levels;
     mTextureWidth  = renderTarget11->getWidth();
     mTextureHeight = renderTarget11->getHeight();
     mTextureDepth  = 1;
@@ -2124,36 +2125,21 @@ angle::Result TextureStorage11_EGLImage::createSRVForSampler(const gl::Context *
                                                              const TextureHelper11 &texture,
                                                              d3d11::SharedSRV *outSRV)
 {
-    ASSERT(baseLevel == 0);
-    ASSERT(mipLevels == 1);
     ASSERT(outSRV);
 
-    // Create a new SRV only for the swizzle texture.  Otherwise just return the Image's
-    // RenderTarget's SRV.
-    if (texture == mSwizzleTexture)
-    {
-        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
-        srvDesc.Format                    = format;
-        srvDesc.ViewDimension             = D3D11_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MostDetailedMip = mTopLevel + baseLevel;
-        srvDesc.Texture2D.MipLevels       = mipLevels;
+    // Build a fresh SRV over the requested mip range. The underlying TextureHelper11 (from either
+    // the EGLImage's render target or the swizzle texture) carries the full mip chain, so we can
+    // honor baseLevel/mipLevels directly. Previously this path reused the RenderTarget's
+    // single-level SRV, which forced sampling to level 0 only.
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
+    srvDesc.Format                    = format;
+    srvDesc.ViewDimension             = D3D11_SRV_DIMENSION_TEXTURE2D;
+    srvDesc.Texture2D.MostDetailedMip = mTopLevel + baseLevel;
+    srvDesc.Texture2D.MipLevels       = mipLevels;
 
-        ANGLE_TRY(mRenderer->allocateResource(GetImplAs<Context11>(context), srvDesc, texture.get(),
-                                              outSRV));
-        outSRV->setLabels("TexStorageEGLImage.SRV", &mKHRDebugLabel);
-    }
-    else
-    {
-        RenderTarget11 *renderTarget = nullptr;
-        ANGLE_TRY(getImageRenderTarget(context, &renderTarget));
-
-        ASSERT(texture == renderTarget->getTexture());
-
-        const d3d11::SharedSRV *srv;
-        ANGLE_TRY(renderTarget->getShaderResourceView(context, &srv));
-
-        *outSRV = srv->makeCopy();
-    }
+    ANGLE_TRY(mRenderer->allocateResource(GetImplAs<Context11>(context), srvDesc, texture.get(),
+                                          outSRV));
+    outSRV->setLabels("TexStorageEGLImage.SRV", &mKHRDebugLabel);
 
     return angle::Result::Continue;
 }

--- a/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.h
@@ -497,6 +497,7 @@ class TextureStorage11_EGLImage final : public TextureStorage11ImmutableBase
     TextureStorage11_EGLImage(Renderer11 *renderer,
                               EGLImageD3D *eglImage,
                               RenderTarget11 *renderTarget11,
+                              GLuint levels,
                               const std::string &label);
     ~TextureStorage11_EGLImage() override;
 

--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -1668,6 +1668,7 @@ void GenerateCaps(ID3D11Device *device,
     extensions->EGLImageExternalOES                 = true;
     extensions->EGLImageExternalWrapModesEXT        = true;
     extensions->EGLImageExternalEssl3OES            = true;
+    extensions->EGLImageStorageEXT                  = true;
     extensions->EGLStreamConsumerExternalNV         = true;
     extensions->unpackSubimageEXT                   = true;
     extensions->packSubimageNV                      = true;

--- a/src/libANGLE/renderer/d3d/d3d9/Renderer9.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/Renderer9.cpp
@@ -2925,6 +2925,7 @@ TextureStorage *Renderer9::createTextureStorage2D(SwapChainD3D *swapChain, const
 
 TextureStorage *Renderer9::createTextureStorageEGLImage(EGLImageD3D *eglImage,
                                                         RenderTargetD3D *renderTargetD3D,
+                                                        GLuint /*levels*/,
                                                         const std::string &label)
 {
     return new TextureStorage9_EGLImage(this, eglImage, GetAs<RenderTarget9>(renderTargetD3D),

--- a/src/libANGLE/renderer/d3d/d3d9/Renderer9.h
+++ b/src/libANGLE/renderer/d3d/d3d9/Renderer9.h
@@ -280,6 +280,7 @@ class Renderer9 : public RendererD3D
                                            const std::string &label) override;
     TextureStorage *createTextureStorageEGLImage(EGLImageD3D *eglImage,
                                                  RenderTargetD3D *renderTargetD3D,
+                                                 GLuint levels,
                                                  const std::string &label) override;
 
     TextureStorage *createTextureStorageBuffer(const gl::OffsetBindingPointer<gl::Buffer> &buffer,

--- a/src/libANGLE/renderer/gl/TextureGL.cpp
+++ b/src/libANGLE/renderer/gl/TextureGL.cpp
@@ -1496,6 +1496,7 @@ angle::Result TextureGL::releaseTexImage(const gl::Context *context)
 
 angle::Result TextureGL::setEGLImageTarget(const gl::Context *context,
                                            gl::TextureType type,
+                                           GLuint /*levels*/,
                                            egl::Image *image)
 {
     const angle::FeaturesGL &features = GetFeaturesGL(context);

--- a/src/libANGLE/renderer/gl/TextureGL.h
+++ b/src/libANGLE/renderer/gl/TextureGL.h
@@ -184,6 +184,7 @@ class TextureGL : public TextureImpl
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     GLint getNativeID() const override;

--- a/src/libANGLE/renderer/metal/TextureMtl.h
+++ b/src/libANGLE/renderer/metal/TextureMtl.h
@@ -123,6 +123,7 @@ class TextureMtl : public TextureImpl
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result setImageExternal(const gl::Context *context,

--- a/src/libANGLE/renderer/metal/TextureMtl.mm
+++ b/src/libANGLE/renderer/metal/TextureMtl.mm
@@ -1286,6 +1286,7 @@ angle::Result TextureMtl::setStorageMultisample(const gl::Context *context,
 
 angle::Result TextureMtl::setEGLImageTarget(const gl::Context *context,
                                             gl::TextureType type,
+                                            GLuint /*levels*/,
                                             egl::Image *image)
 {
     releaseTexture(true);

--- a/src/libANGLE/renderer/null/TextureNULL.cpp
+++ b/src/libANGLE/renderer/null/TextureNULL.cpp
@@ -176,6 +176,7 @@ angle::Result TextureNULL::setStorageExternalMemory(const gl::Context *context,
 
 angle::Result TextureNULL::setEGLImageTarget(const gl::Context *context,
                                              gl::TextureType type,
+                                             GLuint /*levels*/,
                                              egl::Image *image)
 {
     return angle::Result::Continue;

--- a/src/libANGLE/renderer/null/TextureNULL.h
+++ b/src/libANGLE/renderer/null/TextureNULL.h
@@ -134,6 +134,7 @@ class TextureNULL : public TextureImpl
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result setImageExternal(const gl::Context *context,

--- a/src/libANGLE/renderer/vulkan/TextureVk.cpp
+++ b/src/libANGLE/renderer/vulkan/TextureVk.cpp
@@ -1809,6 +1809,7 @@ void TextureVk::handleImmutableSamplerTransition(const vk::ImageHelper *previous
 
 angle::Result TextureVk::setEGLImageTarget(const gl::Context *context,
                                            gl::TextureType type,
+                                           GLuint /*levels*/,
                                            egl::Image *image)
 {
     ContextVk *contextVk = vk::GetImpl(context);

--- a/src/libANGLE/renderer/vulkan/TextureVk.h
+++ b/src/libANGLE/renderer/vulkan/TextureVk.h
@@ -153,6 +153,7 @@ class TextureVk : public TextureImpl, public angle::ObserverInterface
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result setImageExternal(const gl::Context *context,

--- a/src/libANGLE/renderer/wgpu/TextureWgpu.cpp
+++ b/src/libANGLE/renderer/wgpu/TextureWgpu.cpp
@@ -174,6 +174,7 @@ angle::Result TextureWgpu::setStorageExternalMemory(const gl::Context *context,
 
 angle::Result TextureWgpu::setEGLImageTarget(const gl::Context *context,
                                              gl::TextureType type,
+                                             GLuint /*levels*/,
                                              egl::Image *image)
 {
     return angle::Result::Continue;

--- a/src/libANGLE/renderer/wgpu/TextureWgpu.h
+++ b/src/libANGLE/renderer/wgpu/TextureWgpu.h
@@ -134,6 +134,7 @@ class TextureWgpu : public TextureImpl
 
     angle::Result setEGLImageTarget(const gl::Context *context,
                                     gl::TextureType type,
+                                    GLuint levels,
                                     egl::Image *image) override;
 
     angle::Result setImageExternal(const gl::Context *context,


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-5240](https://shapr3d.atlassian.net/browse/GFX-5240)

## Short description (What? How?) 📖
See full story [here](https://shapr3d.atlassian.net/browse/GFX-5240?focusedCommentId=89423). `ExternalImageSiblingImpl11` now remembers the number of mip levels (queried from the `ID3D11Texture`'s description). This can later be queried by `TextureStorage11_EGLImage::createSRVForSampler()` so the shader resource view will see all mip levels.

I checked upstream and none of these changes were made there. No danger of code conflicts 🎉.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Importing (multi-mip-level) D3D11 textures into EGLImages

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-5240]: https://shapr3d.atlassian.net/browse/GFX-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ